### PR TITLE
Remove tags from the ECS cluster (not supported)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,9 @@ resource "aws_ecs_service" "default" {
   task_definition = aws_ecs_task_definition.default.arn
   desired_count   = var.desired_count
   launch_type     = "FARGATE"
-  tags            = var.tags
+  # https://aws.amazon.com/about-aws/whats-new/2018/11/amazon-ecs-and-aws-fargate-now-allow-resources-tagging-/
+  # Tags are not supported (yet)
+  # tags            = var.tags
 
   network_configuration {
     security_groups  = [aws_security_group.ecs.id]


### PR DESCRIPTION
Removed the tags from the ECS cluster ([again](https://github.com/schubergphilis/terraform-aws-mcaf-fargate/commit/540eddbf8f86519ce4c7ce872d96af9150ad9817)).

Tagging is only possible with the "new ARN format". Which is currently a manual opt-in, and new ECS clusters will get the new format from 1-2-2020 ([source](https://aws.amazon.com/about-aws/whats-new/2018/11/amazon-ecs-and-aws-fargate-now-allow-resources-tagging-/
)).

To prevent people adding the tags again in the future (with good intentions) kept the code but commented, with documentation on why it's disabled.