### PR TITLE
 [IOT-478] Add DNS configuration and improve redirect

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,4 +1,5 @@
 locals {
+  alb_hostname = local.load_balancer != null ? aws_alb.default[0].dns_name : null
   load_balancer_count = local.load_balancer != null ? 1 : 0
 }
 

--- a/alb.tf
+++ b/alb.tf
@@ -45,6 +45,7 @@ resource "aws_alb_listener" "http" {
     type = "redirect"
 
     redirect {
+      host        = local.application_fqdn
       port        = 443
       protocol    = "HTTPS"
       status_code = "HTTP_301"
@@ -76,8 +77,7 @@ resource "aws_alb_listener" "https" {
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = var.ssl_policy
-  certificate_arn   = var.certificate_arn
-
+  certificate_arn   = aws_acm_certificate.fargate.arn
 
   default_action {
     type             = "forward"

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,34 @@
+locals {
+    application_fqdn = replace("${var.subdomain}.${data.aws_route53_zone.current.name}", "/[.]$/", "")
+}
+
+data "aws_route53_zone" "current" {
+  zone_id = var.zone_id
+}
+
+resource "aws_route53_record" "fargate" {
+  zone_id = data.aws_route53_zone.current.zone_id
+  name    = local.application_fqdn
+  type    = "CNAME"
+  ttl     = "5"
+  records = [aws_alb.default.dns_name]
+}
+
+resource "aws_acm_certificate" "fargate" {
+  domain_name       = aws_route53_record.fargate.fqdn
+  validation_method = "DNS"
+  tags              = var.tags
+}
+
+resource "aws_route53_record" "fargate_cert_validation" {
+  zone_id = data.aws_route53_zone.current.zone_id
+  name    = aws_acm_certificate.fargate.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.fargate.domain_validation_options.0.resource_record_type
+  ttl     = 60
+  records = [aws_acm_certificate.fargate.domain_validation_options.0.resource_record_value]
+}
+
+resource "aws_acm_certificate_validation" "fargate" {
+  certificate_arn         = aws_acm_certificate.fargate.arn
+  validation_record_fqdns = [aws_route53_record.fargate_cert_validation.fqdn]
+}

--- a/dns.tf
+++ b/dns.tf
@@ -1,19 +1,19 @@
 locals {
-  application_fqdn = var.subdomain != null ? replace(
+  application_fqdn = var.subdomain != null && local.load_balancer != null ? replace(
     "${var.subdomain.name}.${data.aws_route53_zone.current[0].name}", "/[.]$/", "",
   ) : null
 
   certificate_arn   = var.certificate_arn != null ? var.certificate_arn : aws_acm_certificate.default.0.arn
-  certificate_count = var.certificate_arn == null && var.subdomain != null ? 1 : 0
+  certificate_count = var.certificate_arn == null && var.subdomain != null ? local.load_balancer_count : 0
 }
 
 data "aws_route53_zone" "current" {
-  count   = var.subdomain != null ? 1 : 0
+  count   = var.subdomain != null ? local.load_balancer_count : 0
   zone_id = var.subdomain.zone_id
 }
 
 resource "aws_route53_record" "default" {
-  count   = var.subdomain != null ? 1 : 0
+  count   = var.subdomain != null ? local.load_balancer_count : 0
   zone_id = data.aws_route53_zone.current[0].zone_id
   name    = local.application_fqdn
   type    = "CNAME"
@@ -22,14 +22,18 @@ resource "aws_route53_record" "default" {
 }
 
 resource "aws_acm_certificate" "default" {
-  count             = var.certificate_count
+  count             = local.certificate_count
   domain_name       = local.application_fqdn
   validation_method = "DNS"
   tags              = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "cert_validation" {
-  count   = var.certificate_count
+  count   = local.certificate_count
   zone_id = data.aws_route53_zone.current[0].zone_id
   name    = aws_acm_certificate.default[0].domain_validation_options.0.resource_record_name
   type    = aws_acm_certificate.default[0].domain_validation_options.0.resource_record_type

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  region = var.region != null ? var.region : data.aws_region.current.name
+  load_balancer = var.public_subnet_ids != null ? { create : true } : null
+  region        = var.region != null ? var.region : data.aws_region.current.name
 }
 
 data "aws_region" "current" {}
@@ -62,15 +63,19 @@ resource "aws_ecs_task_definition" "default" {
 
 resource "aws_security_group" "ecs" {
   name        = "${var.name}-ecs"
-  description = "Allow inbound access from the ALB only"
+  description = "Allow access to and from the ECS cluster"
   vpc_id      = var.vpc_id
   tags        = var.tags
 
-  ingress {
-    protocol        = "tcp"
-    from_port       = var.port
-    to_port         = var.port
-    security_groups = [aws_security_group.alb.id]
+  dynamic ingress {
+    for_each = local.load_balancer
+
+    content {
+      protocol        = "tcp"
+      from_port       = var.port
+      to_port         = var.port
+      security_groups = [aws_security_group.alb.id]
+    }
   }
 
   egress {
@@ -99,10 +104,14 @@ resource "aws_ecs_service" "default" {
     assign_public_ip = var.public_ip
   }
 
-  load_balancer {
-    target_group_arn = aws_alb_target_group.default.id
-    container_name   = "app-${var.name}"
-    container_port   = var.port
+  dynamic load_balancer {
+    for_each = local.load_balancer
+
+    content {
+      target_group_arn = aws_alb_target_group.default.id
+      container_name   = "app-${var.name}"
+      container_port   = var.port
+    }
   }
 
   depends_on = [aws_alb_listener.https]

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  load_balancer = var.public_subnet_ids != null ? { create : true } : null
+  load_balancer = var.public_subnet_ids != null ? { create : true } : {}
   region        = var.region != null ? var.region : data.aws_region.current.name
 }
 
@@ -74,7 +74,7 @@ resource "aws_security_group" "ecs" {
       protocol        = "tcp"
       from_port       = var.port
       to_port         = var.port
-      security_groups = [aws_security_group.alb.id]
+      security_groups = [aws_security_group.alb.0.id]
     }
   }
 
@@ -108,7 +108,7 @@ resource "aws_ecs_service" "default" {
     for_each = local.load_balancer
 
     content {
-      target_group_arn = aws_alb_target_group.default.id
+      target_group_arn = aws_alb_target_group.default.0.id
       container_name   = "app-${var.name}"
       container_port   = var.port
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "name" {
   description = "Name of the fargate deployment"
 }
 
+output "fqdn" {
+  value       = aws_route53_record.fargate.fqdn
+  description = "FQDN of the route53 endpoint"
+}
+
 output "hostname" {
   value       = aws_alb.default.dns_name
   description = "Hostname of the Application Loadbalancer"

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,12 +4,12 @@ output "name" {
 }
 
 output "fqdn" {
-  value       = aws_route53_record.fargate.fqdn
+  value       = local.application_fqdn
   description = "FQDN of the route53 endpoint"
 }
 
 output "hostname" {
-  value       = aws_alb.default.dns_name
+  value       = local.alb_hostname
   description = "Hostname of the Application Loadbalancer"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -84,15 +84,20 @@ variable "ssl_policy" {
   description = "SSL Policy for the ALB Listener"
 }
 
-variable "certificate_arn" {
-  type        = string
-  description = "Certificate ARN for the ALB Listener"
-}
-
 variable "health_check_path" {
   type        = string
   default     = "/"
   description = "Path used to check the health of the container"
+}
+
+variable "subdomain" {
+  type        = string
+  description = "The DNS subdomain for the ALB"
+}
+
+variable "zone_id" {
+  type        = string
+  description = "ID of the Route53 zone in which to create the subdomain record for the ALB"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,10 +3,10 @@ variable "name" {
   description = "Name of the Fargate cluster"
 }
 
-variable "desired_count" {
-  type        = number
-  default     = 1
-  description = "Desired number of docker containers to run"
+variable "cidr_blocks" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "CIDR block to allow access to the ALB"
 }
 
 variable "cpu" {
@@ -15,16 +15,10 @@ variable "cpu" {
   description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
 }
 
-variable "memory" {
+variable "desired_count" {
   type        = number
-  default     = 2048
-  description = "Fargate instance memory to provision (in MiB)"
-}
-
-variable "image" {
-  type        = string
-  default     = "nginx:latest"
-  description = "Docker image to run in the ECS cluster"
+  default     = 1
+  description = "Desired number of docker containers to run"
 }
 
 variable "environment" {
@@ -33,38 +27,28 @@ variable "environment" {
   description = "Environment variables defined in the docker container"
 }
 
+variable "health_check_path" {
+  type        = string
+  default     = "/"
+  description = "Path used to check the health of the container"
+}
+
+variable "image" {
+  type        = string
+  default     = "nginx:latest"
+  description = "Docker image to run in the ECS cluster"
+}
+
+variable "memory" {
+  type        = number
+  default     = 2048
+  description = "Fargate instance memory to provision (in MiB)"
+}
+
 variable "port" {
   type        = number
   default     = 3000
   description = "Port exposed by the docker image to redirect traffic to"
-}
-
-variable "role_policy" {
-  type        = string
-  description = "The Policy document for the role"
-}
-
-variable "region" {
-  type        = string
-  default     = null
-  description = "The region this fargate cluster should reside in, defaults to the region used by the callee"
-}
-
-variable "vpc_id" {
-  type        = string
-  description = "AWS vpc id"
-}
-
-variable "cidr_blocks" {
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "CIDR block to allow access to the ALB"
-
-}
-
-variable "public_subnet_ids" {
-  type        = list(string)
-  description = "List of subnet IDs assigned to the ALB"
 }
 
 variable "private_subnet_ids" {
@@ -78,21 +62,36 @@ variable "public_ip" {
   description = "Assign a public ip to the service"
 }
 
+variable "public_subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs assigned to the ALB"
+}
+
+variable "region" {
+  type        = string
+  default     = null
+  description = "The region this fargate cluster should reside in, defaults to the region used by the callee"
+}
+
+variable "role_policy" {
+  type        = string
+  description = "The Policy document for the role"
+}
+
 variable "ssl_policy" {
   type        = string
   default     = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   description = "SSL Policy for the ALB Listener"
 }
 
-variable "health_check_path" {
-  type        = string
-  default     = "/"
-  description = "Path used to check the health of the container"
-}
-
 variable "subdomain" {
   type        = string
   description = "The DNS subdomain for the ALB"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "AWS vpc id"
 }
 
 variable "zone_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "cidr_blocks" {
   description = "CIDR block to allow access to the ALB"
 }
 
+variable "certificate_arn" {
+  type        = string
+  default     = null
+  description = "Certificate ARN for the ALB Listener"
+}
+
 variable "cpu" {
   type        = number
   default     = 1024
@@ -64,6 +70,7 @@ variable "public_ip" {
 
 variable "public_subnet_ids" {
   type        = list(string)
+  default     = null
   description = "List of subnet IDs assigned to the ALB"
 }
 
@@ -85,18 +92,17 @@ variable "ssl_policy" {
 }
 
 variable "subdomain" {
-  type        = string
-  description = "The DNS subdomain for the ALB"
+  type = object({
+    name    = string,
+    zone_id = string
+  })
+  default     = null
+  description = "The DNS subdomain and zone ID for the ALB"
 }
 
 variable "vpc_id" {
   type        = string
   description = "AWS vpc id"
-}
-
-variable "zone_id" {
-  type        = string
-  description = "ID of the Route53 zone in which to create the subdomain record for the ALB"
 }
 
 variable "tags" {


### PR DESCRIPTION
This PR adds the DNS configuration (route53) to the MCAF module. This simplifies the usage of the module and allows to improve the HTTP->HTTPS functionality.

The redirect now redirects explicitly to the given domain (`subdomain`) instead of the user input. This prevents possible spoofing the redirect by specifying a different Host in the request