### PR TITLE
Add target group health check settings

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -84,13 +84,13 @@ resource "aws_lb_target_group" "default" {
   }
 
   health_check {
-    interval            = var.health.interval
+    interval            = var.health_check != null ? var.health_check.interval : null
     timeout             = var.protocol != "TCP" ? 3 : null
     protocol            = var.protocol
-    path                = var.protocol != "TCP" ? var.health.path : null
+    path                = var.protocol != "TCP" ? (var.health_check != null ? var.health_check.path : null) : null
     matcher             = var.protocol != "TCP" ? 200 : null
-    healthy_threshold   = var.health.healthy_threshold
-    unhealthy_threshold = var.health.unhealthy_threshold
+    healthy_threshold   = var.health_check != null ? var.health_check.healthy_threshold : null
+    unhealthy_threshold = var.health_check != null ? var.health_check.unhealthy_threshold : null
   }
 }
 

--- a/lb.tf
+++ b/lb.tf
@@ -84,13 +84,13 @@ resource "aws_lb_target_group" "default" {
   }
 
   health_check {
-    interval            = var.health_check != null ? var.health_check.interval : null
+    interval            = var.health_check.interval
     timeout             = var.protocol != "TCP" ? 3 : null
     protocol            = var.protocol
-    path                = var.protocol != "TCP" ? (var.health_check != null ? var.health_check.path : null) : null
+    path                = var.protocol != "TCP" ? (var.health_check.path) : null
     matcher             = var.protocol != "TCP" ? 200 : null
-    healthy_threshold   = var.health_check != null ? var.health_check.healthy_threshold : null
-    unhealthy_threshold = var.health_check != null ? var.health_check.unhealthy_threshold : null
+    healthy_threshold   = var.health_check.healthy_threshold
+    unhealthy_threshold = var.health_check.unhealthy_threshold
   }
 }
 

--- a/lb.tf
+++ b/lb.tf
@@ -84,13 +84,13 @@ resource "aws_lb_target_group" "default" {
   }
 
   health_check {
-    interval            = 30
+    interval            = var.health_check_interval
     timeout             = var.protocol != "TCP" ? 3 : null
     protocol            = var.protocol
     path                = var.protocol != "TCP" ? var.health_check_path : null
     matcher             = var.protocol != "TCP" ? 200 : null
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = var.healthy_threshold
+    unhealthy_threshold = var.unhealthy_threshold
   }
 }
 

--- a/lb.tf
+++ b/lb.tf
@@ -84,13 +84,13 @@ resource "aws_lb_target_group" "default" {
   }
 
   health_check {
-    interval            = var.health_check_interval
+    interval            = var.health.interval
     timeout             = var.protocol != "TCP" ? 3 : null
     protocol            = var.protocol
-    path                = var.protocol != "TCP" ? var.health_check_path : null
+    path                = var.protocol != "TCP" ? var.health.path : null
     matcher             = var.protocol != "TCP" ? 200 : null
-    healthy_threshold   = var.healthy_threshold
-    unhealthy_threshold = var.unhealthy_threshold
+    healthy_threshold   = var.health.healthy_threshold
+    unhealthy_threshold = var.health.unhealthy_threshold
   }
 }
 

--- a/lb.tf
+++ b/lb.tf
@@ -87,7 +87,7 @@ resource "aws_lb_target_group" "default" {
     interval            = var.health_check.interval
     timeout             = var.protocol != "TCP" ? 3 : null
     protocol            = var.protocol
-    path                = var.protocol != "TCP" ? (var.health_check.path) : null
+    path                = var.protocol != "TCP" ? var.health_check.path : null
     matcher             = var.protocol != "TCP" ? 200 : null
     healthy_threshold   = var.health_check.healthy_threshold
     unhealthy_threshold = var.health_check.unhealthy_threshold

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,12 @@ variable "health_check" {
     path                = string,
     unhealthy_threshold = number
   })
-  default     = null
+  default     = {
+    healthy_threshold   = 3,
+    interval            = 30,
+    path                = null,
+    unhealthy_threshold = 3
+  }
   description = "Health check settings for the container"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,28 +39,15 @@ variable "secrets" {
   description = "An object representing the secret to expose to the docker container"
 }
 
-variable "health_check_interval" {
-  type        = string
-  default     = 30
-  description = "Interval used to check the health of the container"
-}
-
-variable "health_check_path" {
-  type        = string
-  default     = "/"
-  description = "Path used to check the health of the container"
-}
-
-variable "healthy_threshold" {
-  type        = string
-  default     = 3
-  description = "Number of consecutive health check successes"
-}
-
-variable "unhealthy_threshold" {
-  type        = string
-  default     = 3
-  description = "Number of consecutive health check failures"
+variable "health" {
+  type = object({
+    interval            = string,
+    path                = string,
+    healthy_threshold   = number,
+    unhealthy_threshold = number
+  })
+  default     = null
+  description = "Health check settings used to check the health of the container"
 }
 
 variable "image" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,15 +39,15 @@ variable "secrets" {
   description = "An object representing the secret to expose to the docker container"
 }
 
-variable "health" {
+variable "health_check" {
   type = object({
+    healthy_threshold   = number,
     interval            = number,
     path                = string,
-    healthy_threshold   = number,
     unhealthy_threshold = number
   })
   default     = null
-  description = "Health check settings used to check the health of the container"
+  description = "Health check settings for the container"
 }
 
 variable "image" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,10 +39,28 @@ variable "secrets" {
   description = "An object representing the secret to expose to the docker container"
 }
 
+variable "health_check_interval" {
+  type        = string
+  default     = 30
+  description = "Interval used to check the health of the container"
+}
+
 variable "health_check_path" {
   type        = string
   default     = "/"
   description = "Path used to check the health of the container"
+}
+
+variable "healthy_threshold" {
+  type        = string
+  default     = 3
+  description = "Number of consecutive health check successes"
+}
+
+variable "unhealthy_threshold" {
+  type        = string
+  default     = 3
+  description = "Number of consecutive health check failures"
 }
 
 variable "image" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "health_check" {
     path                = string,
     unhealthy_threshold = number
   })
-  default     = {
+  default = {
     healthy_threshold   = 3,
     interval            = 30,
     path                = null,

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "secrets" {
 
 variable "health" {
   type = object({
-    interval            = string,
+    interval            = number,
     path                = string,
     healthy_threshold   = number,
     unhealthy_threshold = number


### PR DESCRIPTION
This will add in target group health check settings as variables which will make it possble to pass custom values when using the module. The variables have defaults which makes them optional and are set to the original hardcoded values.