### PR TITLE
Add cross-zone LB feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | cidr\_blocks | CIDR block to allow access to the LB | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | cpu | Fargate instance CPU units to provision (1 vCPU = 1024 CPU units) | `number` | `1024` | no |
 | desired\_count | Desired number of docker containers to run | `number` | `1` | no |
+| enable\_cross\_zone\_load\_balancing | Enable cross-zone load balancing of the (network) load balancer | `bool` | `false` | no |
 | environment | Environment variables defined in the docker container | `map` | `{}` | no |
 | health\_check | Health check settings for the container | <pre>object({<br>    healthy_threshold   = number,<br>    interval            = number,<br>    path                = string,<br>    unhealthy_threshold = number<br>  })</pre> | <pre>{<br>  "healthy_threshold": 3,<br>  "interval": 30,<br>  "path": null,<br>  "unhealthy_threshold": 3<br>}</pre> | no |
 | load\_balancer\_eip | Whether to create Elastic IPs for the load balancer | `bool` | `false` | no |
@@ -50,7 +51,7 @@
 |------|-------------|
 | cluster\_arn | The ARN of the ECS cluster |
 | fqdn | FQDN of the route53 endpoint |
-| hostname | Hostname of the Application Load balancer |
+| hostname | Hostname of the Application load balancer |
 | http\_listener\_arn | The ARN of the HTTP listener |
 | https\_listener\_arn | The ARN of the HTTPS listener |
 | load\_balancer\_eips | The Elastic IPs of the load balancer |

--- a/lb.tf
+++ b/lb.tf
@@ -48,13 +48,14 @@ resource "aws_eip" "lb" {
 }
 
 resource "aws_lb" "default" {
-  count              = local.load_balancer_count
-  name               = var.name
-  internal           = var.load_balancer_internal #tfsec:ignore:AWS005
-  load_balancer_type = var.protocol == "TCP" ? "network" : "application"
-  subnets            = var.load_balancer_eip ? null : var.load_balancer_subnet_ids
-  security_groups    = var.protocol != "TCP" ? [aws_security_group.lb[0].id] : null
-  tags               = var.tags
+  count                            = local.load_balancer_count
+  name                             = var.name
+  internal                         = var.load_balancer_internal #tfsec:ignore:AWS005
+  load_balancer_type               = var.protocol == "TCP" ? "network" : "application"
+  enable_cross_zone_load_balancing = var.protocol == "TCP" ? var.enable_cross_zone_load_balancing : false
+  subnets                          = var.load_balancer_eip ? null : var.load_balancer_subnet_ids
+  security_groups                  = var.protocol != "TCP" ? [aws_security_group.lb[0].id] : null
+  tags                             = var.tags
 
   dynamic "subnet_mapping" {
     for_each = local.eip_subnets

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "fqdn" {
 
 output "hostname" {
   value       = local.lb_hostname
-  description = "Hostname of the Application Load balancer"
+  description = "Hostname of the Application load balancer"
 }
 
 output "http_listener_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "desired_count" {
   description = "Desired number of docker containers to run"
 }
 
+variable "enable_cross_zone_load_balancing" {
+  type        = bool
+  default     = false
+  description = "Enable cross-zone load balancing of the (network) load balancer"
+}
+
 variable "ecs_subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs assigned to ECS cluster"


### PR DESCRIPTION
This PR adds the "Cross zone loadbalancing" ([documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html)) feature to the Network loadbalancers