### PR TITLE
Rebuild to fix TF issues

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -32,24 +32,17 @@ resource "aws_acm_certificate" "default" {
   }
 }
 
-resource "aws_route53_record" "cert_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.default[0].domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  name    = each.value.name
-  records = [each.value.record]
-  ttl     = 60
-  type    = each.value.type
+resource "aws_route53_record" "validation" {
+  count   = local.certificate_count
+  name    = aws_acm_certificate.default[count.index].domain_validation_options.*.resource_record_name[0]
+  records = [aws_acm_certificate.default[count.index].domain_validation_options.*.resource_record_value[0]]
+  type    = aws_acm_certificate.default[count.index].domain_validation_options.*.resource_record_type[0]
   zone_id = data.aws_route53_zone.current[0].zone_id
+  ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "default" {
   count                   = local.certificate_count
   certificate_arn         = local.certificate_arn
-  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+  validation_record_fqdns = [aws_route53_record.validation[count.index].fqdn]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,7 @@ output "https_listener_arn" {
 }
 
 output "load_balancer_eips" {
-  value       = values(aws_eip.lb).*.public_ip
+  value       = try(aws_eip.lb.*.public_ip, null)
   description = "The Elastic IPs of the load balancer"
 }
 


### PR DESCRIPTION
This PR fixes some TF issues that popped up when building new infrastructure from scratch.

```
  on .terraform/modules/br001oc_cb_opco.opco_proxy.proxy_container/dns.tf line 36, in resource "aws_route53_record" "cert_validation":
  36:   for_each = {
  37:     for dvo in aws_acm_certificate.default[0].domain_validation_options : dvo.domain_name => {
  38:       name   = dvo.resource_record_name
  39:       record = dvo.resource_record_value
  40:       type   = dvo.resource_record_type
  41:     }
  42:   }
```
Same fix implemented as in https://github.com/schubergphilis/terraform-aws-mcaf-cloudfront/pull/50

```
Error: Invalid for_each argument

  on .terraform/modules/br001oc_cb_opco.opco_proxy.proxy_container/lb.tf line 44, in resource "aws_eip" "lb":
  44:   for_each = toset(local.eip_subnets)

The "for_each" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the for_each depends on.
```
Changed to a `count`, this does trigger a recreate of the Elastic IP's as well as the Loadbalancer (if EIP's are used) since the index is changed from the name of the subnet to an index.

