### PR TITLE
EIPs are only allowed for Network Load Balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | enable\_cross\_zone\_load\_balancing | Enable cross-zone load balancing of the (network) load balancer | `bool` | `false` | no |
 | environment | Environment variables defined in the docker container | `map(string)` | `{}` | no |
 | health\_check | Health check settings for the container | <pre>object({<br>    healthy_threshold   = number,<br>    interval            = number,<br>    path                = string,<br>    unhealthy_threshold = number<br>  })</pre> | <pre>{<br>  "healthy_threshold": 3,<br>  "interval": 30,<br>  "path": null,<br>  "unhealthy_threshold": 3<br>}</pre> | no |
-| load\_balancer\_eip | Whether to create Elastic IPs for the load balancer | `bool` | `false` | no |
+| load\_balancer\_eip | Whether to create Elastic IPs for the load balancer (only supported when protocol == 'TCP') | `bool` | `false` | no |
 | load\_balancer\_internal | Set to true to create an internal load balancer | `bool` | `false` | no |
 | load\_balancer\_subnet\_ids | List of subnet IDs assigned to the LB | `list(string)` | `null` | no |
 | memory | Fargate instance memory to provision (in MiB) | `number` | `2048` | no |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | enable\_cross\_zone\_load\_balancing | Enable cross-zone load balancing of the (network) load balancer | `bool` | `false` | no |
 | environment | Environment variables defined in the docker container | `map(string)` | `{}` | no |
 | health\_check | Health check settings for the container | <pre>object({<br>    healthy_threshold   = number,<br>    interval            = number,<br>    path                = string,<br>    unhealthy_threshold = number<br>  })</pre> | <pre>{<br>  "healthy_threshold": 3,<br>  "interval": 30,<br>  "path": null,<br>  "unhealthy_threshold": 3<br>}</pre> | no |
-| load\_balancer\_eip | Whether to create Elastic IPs for the load balancer (only supported when protocol == 'TCP') | `bool` | `false` | no |
+| load\_balancer\_eip | Whether to create Elastic IPs for the load balancer (when `var.protocol` is `TCP`) | `bool` | `false` | no |
 | load\_balancer\_internal | Set to true to create an internal load balancer | `bool` | `false` | no |
 | load\_balancer\_subnet\_ids | List of subnet IDs assigned to the LB | `list(string)` | `null` | no |
 | memory | Fargate instance memory to provision (in MiB) | `number` | `2048` | no |

--- a/lb.tf
+++ b/lb.tf
@@ -4,7 +4,7 @@ locals {
   https_listener_arn  = local.load_balancer != null && var.protocol != "TCP" ? aws_lb_listener.https[0].arn : null
   tcp_listener_arn    = local.load_balancer != null && var.protocol == "TCP" ? aws_lb_listener.tcp[0].arn : null
   load_balancer_count = local.load_balancer != null ? 1 : 0
-  eip_subnets         = var.load_balancer_eip ? var.load_balancer_subnet_ids : []
+  eip_subnets         = var.load_balancer_eip && var.protocol == "TCP" ? var.load_balancer_subnet_ids : []
 
   target_group_arn = local.load_balancer == null ? null : (
     length(aws_lb_target_group.default) > 0 ? aws_lb_target_group.default[0].arn : null

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "image" {
 variable "load_balancer_eip" {
   type        = bool
   default     = false
-  description = "Whether to create Elastic IPs for the load balancer"
+  description = "Whether to create Elastic IPs for the load balancer (only supported when protocol == 'TCP')"
 }
 
 variable "load_balancer_internal" {

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "image" {
 variable "load_balancer_eip" {
   type        = bool
   default     = false
-  description = "Whether to create Elastic IPs for the load balancer (only supported when protocol == 'TCP')"
+  description = "Whether to create Elastic IPs for the load balancer (when `var.protocol` is `TCP`)"
 }
 
 variable "load_balancer_internal" {


### PR DESCRIPTION
Currently
```
module "fargate" {
  source = "github.com/schubergphilis/terraform-aws-mcaf-fargate?ref=v0.8.5"

  ...
  load_balancer_eip                   = true
  protocol                             = "HTTP" # default in module
  ...
}
```

Will result in 
<img width="1419" alt="afbeelding" src="https://user-images.githubusercontent.com/7990862/110928859-a16a6600-8327-11eb-8b3a-31239bc1d9a8.png">

Because the combination of protocol "HTTP" (default value for `var.protocol`) will result in a Application Load Balancer and assigning a EIP is only allowed for a Network Load Balancer as per https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html:
> [Application Load Balancers] You must specify subnets from at least two Availability Zones. You cannot specify Elastic IP addresses for your subnets. 
> [Network Load Balancers] You can specify subnets from one or more Availability Zones. You can specify one Elastic IP address per subnet if you need static IP addresses for your internet-facing load balancer.

Proposed change: explicitely state that the protocol has to be `"TCP"` when `load_balancer_eip` is used.
