### PR TITLE
Add tagging on the Listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13.0 |
-| aws | >= 3.10 |
+| aws | >= 3.40 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.10 |
+| aws | >= 3.40 |
 
 ## Inputs
 

--- a/lb.tf
+++ b/lb.tf
@@ -80,6 +80,7 @@ resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.default[0].id
   port              = 80
   protocol          = "HTTP"
+  tags              = var.tags
 
   default_action {
     type = "redirect"
@@ -125,6 +126,7 @@ resource "aws_lb_listener" "https" {
   protocol          = "HTTPS"
   ssl_policy        = var.ssl_policy
   certificate_arn   = local.certificate_arn
+  tags              = var.tags
 
   default_action {
     type             = "forward"
@@ -137,6 +139,7 @@ resource "aws_lb_listener" "tcp" {
   load_balancer_arn = aws_lb.default[0].id
   port              = var.port
   protocol          = "TCP"
+  tags              = var.tags
 
   default_action {
     type             = "forward"

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.10"
+    aws = ">= 3.40"
   }
 }


### PR DESCRIPTION
The LoadBalancer listeners now support tags (https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3400-may-13-2021)