### PR TITLE
Don't create certificate if protocol is TCP

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -4,7 +4,7 @@ locals {
   ) : null
 
   certificate_arn   = var.certificate_arn != null ? var.certificate_arn : aws_acm_certificate.default[0].arn
-  certificate_count = var.certificate_arn == null && var.subdomain != null ? local.load_balancer_count : 0
+  certificate_count = var.certificate_arn == null && var.subdomain != null && var.protocol != "TCP" ? local.load_balancer_count : 0
 }
 
 data "aws_route53_zone" "current" {

--- a/lb.tf
+++ b/lb.tf
@@ -115,7 +115,7 @@ resource "aws_lb_target_group" "default" {
 
   stickiness {
     enabled = var.target_group_stickiness
-    type    = var.protocol == "HTTP" || var.protocol == "HTTPS" ? "lb_cookie" : "source_ip"
+    type    = var.protocol == "HTTP" ? "lb_cookie" : "source_ip"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,11 @@ variable "protocol" {
   type        = string
   default     = "HTTP"
   description = "The target protocol"
+
+  validation {
+    condition     = contains(["HTTP", "TCP"], var.protocol)
+    error_message = "Allowed values for protocol are \"HTTP\" or \"TCP\"."
+  }
 }
 
 variable "public_ip" {


### PR DESCRIPTION
If the protocol is `TCP`, only a TCP listener is created. And that one is not (and cannot) be asigned to a certificate.
But there is certificate created which is not in use. 

As a result there is a danling certificate which is not eligable for renewal, ending up in Security Hub (`ACM certificates should be renewed after a specified time period` ([source](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-acm-1)).

This PR fixes:

- Don't create a certificate for TCP
- Add validation on protocal variable (`HTTP` or `TCP`)
- Remove single reference to `HTTPS` as protocol value. HTTP = HTTPS basically