### PR TITLE
Fix certificate arn determination

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -3,7 +3,7 @@ locals {
     "${var.subdomain.name}.${data.aws_route53_zone.current[0].name}", "/[.]$/", "",
   ) : null
 
-  certificate_arn   = var.certificate_arn != null ? var.certificate_arn : aws_acm_certificate.default[0].arn
+  certificate_arn   = var.certificate_arn != null ? var.certificate_arn : var.protocol != "TCP" ? aws_acm_certificate.default[0].arn : null
   certificate_count = var.certificate_arn == null && var.subdomain != null && var.protocol != "TCP" ? local.load_balancer_count : 0
 }
 


### PR DESCRIPTION
Made a small mistake with the TCP listener certificate check:
```
   on xxx/dns.tf line 6, in locals:
│    6:   certificate_arn   = var.certificate_arn != null ? var.certificate_arn : aws_acm_certificate.default[0].arn
│     ├────────────────
│     │ aws_acm_certificate.default is empty tuple
│ 
│ The given key does not identify an element in this collection value.
╵
```