### PR TITLE
Add tag propagation to the Fargate Task

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,7 @@ resource "aws_ecs_service" "default" {
   task_definition = aws_ecs_task_definition.default.arn
   desired_count   = var.desired_count
   launch_type     = var.service_launch_type
+  propagate_tags  = "TASK_DEFINITION"
 
   network_configuration {
     security_groups  = [aws_security_group.ecs.id]


### PR DESCRIPTION
This PR makes sure the tags are being applied to the Fargate task that is started. It cannot be set explicitly, but the `propagate_tags` attribute tell which tags to be propagated [source](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html#ECS-CreateService-request-propagateTags). Currently the tasks are not tagged making cost insights annoying/impossible.

The value is "hardcoded" to `TASK_DEFINITION` for the reason that we cannot set the tags on the ECS Service (https://github.com/hashicorp/terraform-provider-aws/issues/7373)
