### PR TITLE
Add (and by default enabled) ContainerInsights

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | cidr\_blocks | CIDR block to allow access to the LB | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | cpu | Fargate instance CPU units to provision (1 vCPU = 1024 CPU units) | `number` | `1024` | no |
 | desired\_count | Desired number of docker containers to run | `number` | `1` | no |
+| enable\_container\_insights | Enable Cloudwatch Container Insights | `bool` | `true` | no |
 | enable\_cross\_zone\_load\_balancing | Enable cross-zone load balancing of the (network) load balancer | `bool` | `false` | no |
 | environment | Environment variables defined in the docker container | `map(string)` | `{}` | no |
 | health\_check | Health check settings for the container | <pre>object({<br>    healthy_threshold   = number,<br>    interval            = number,<br>    path                = string,<br>    unhealthy_threshold = number<br>  })</pre> | <pre>{<br>  "healthy_threshold": 3,<br>  "interval": 30,<br>  "path": null,<br>  "unhealthy_threshold": 3<br>}</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ resource "aws_security_group" "ecs" {
     for_each = local.load_balancer
 
     content {
+      description     = "Allow access from the ECS cluster"
       protocol        = "tcp"
       from_port       = var.port
       to_port         = var.port
@@ -86,6 +87,7 @@ resource "aws_security_group" "ecs" {
   }
 
   egress {
+    description = "Allow all outgoing traffic"
     protocol    = "-1"
     from_port   = 0
     to_port     = 0
@@ -107,6 +109,11 @@ resource "aws_ecs_cluster" "default" {
     content {
       capacity_provider = default_capacity_provider_strategy.value["name"]
     }
+  }
+
+  setting {
+    name  = "containerInsights"
+    value = var.enable_container_insights ? "enabled" : "disabled"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "enable_cross_zone_load_balancing" {
   description = "Enable cross-zone load balancing of the (network) load balancer"
 }
 
+variable "enable_container_insights" {
+  type        = bool
+  default     = true
+  description = "Enable Cloudwatch Container Insights"
+}
+
 variable "environment" {
   type        = map(string)
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -33,16 +33,16 @@ variable "ecs_subnet_ids" {
   description = "List of subnet IDs assigned to ECS cluster"
 }
 
-variable "enable_cross_zone_load_balancing" {
-  type        = bool
-  default     = false
-  description = "Enable cross-zone load balancing of the (network) load balancer"
-}
-
 variable "enable_container_insights" {
   type        = bool
   default     = true
   description = "Enable Cloudwatch Container Insights"
+}
+
+variable "enable_cross_zone_load_balancing" {
+  type        = bool
+  default     = false
+  description = "Enable cross-zone load balancing of the (network) load balancer"
 }
 
 variable "environment" {


### PR DESCRIPTION
This PR adds (and by default) enabled CloudWatch Container Insights ([source](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html))

Popped up as a TFSec warning:

```
 Legacy ID:  AWS090
  Impact:     Not all metrics and logs may be gathered for containers when Container Insights isn't enabled
  Resolution: Enable Container Insights

  More Info:
  - https://tfsec.dev/docs/aws/ecs/enable-container-insight#aws/ecs 
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster#setting 
  - https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html 
```