### PR TITLE
Support AWS provider V4

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+        uses: triat/terraform-security-scan@v3.0.1

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | enable\_cross\_zone\_load\_balancing | Enable cross-zone load balancing of the (network) load balancer | `bool` | `false` | no |
 | environment | Environment variables defined in the docker container | `map(string)` | `{}` | no |
 | health\_check | Health check settings for the container | <pre>object({<br>    healthy_threshold   = number,<br>    interval            = number,<br>    path                = string,<br>    unhealthy_threshold = number<br>  })</pre> | <pre>{<br>  "healthy_threshold": 3,<br>  "interval": 30,<br>  "path": null,<br>  "unhealthy_threshold": 3<br>}</pre> | no |
+| kms\_key\_id | The custom KMS key ID used encryption of the Cloudwatch log group | `string` | `null` | no |
 | load\_balancer\_deregistration\_delay | The amount of time before a target is deregistered when draining | `number` | `300` | no |
 | load\_balancer\_eip | Whether to create Elastic IPs for the load balancer | `bool` | `false` | no |
 | load\_balancer\_internal | Set to true to create an internal load balancer | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13.0 |
-| aws | >= 3.10 |
+| aws | >= 4.0.0 |
+| source | hashicorp/aws |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.10 |
+| aws | >= 4.0.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 |------|---------|
 | terraform | >= 0.13.0 |
 | aws | >= 4.0.0 |
-| source | hashicorp/aws |
 
 ## Providers
 

--- a/lb.tf
+++ b/lb.tf
@@ -19,25 +19,28 @@ resource "aws_security_group" "lb" {
   tags        = var.tags
 
   ingress {
+    description = "HTTP ingress"
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
-    cidr_blocks = var.cidr_blocks #tfsec:ignore:AWS008
+    cidr_blocks = var.cidr_blocks #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   }
 
   ingress {
+    description = "HTTPS ingress"
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = var.cidr_blocks #tfsec:ignore:AWS008
+    cidr_blocks = var.cidr_blocks #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   }
 
   egress {
-    protocol  = "-1"
-    from_port = 0
-    to_port   = 0
+    description = "Public egress"
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
 
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS009
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sgr
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "aws_iam_role_policy_attachment" "task_execution_role" {
 resource "aws_cloudwatch_log_group" "default" {
   name              = "/ecs/${var.name}"
   retention_in_days = 30
+  kms_key_id        = var.kms_key_id
   tags              = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -110,18 +110,6 @@ resource "aws_ecs_cluster" "default" {
   }
 }
 
-resource "aws_ecs_cluster_capacity_providers" "default" {
-  count              = var.capacity_provider_asg_arn != null ? 1 : 0
-  capacity_providers = [aws_ecs_capacity_provider.default[*].name]
-  cluster_name       = aws_ecs_cluster.default.name
-
-  default_capacity_provider_strategy {
-    base              = 1
-    weight            = 100
-    capacity_provider = aws_ecs_capacity_provider.default[*].name
-  }
-}
-
 resource "aws_ecs_capacity_provider" "default" {
   count = var.capacity_provider_asg_arn != null ? 1 : 0
   name  = "${var.name}-capacity-provider"
@@ -135,6 +123,18 @@ resource "aws_ecs_capacity_provider" "default" {
       status                 = "ENABLED"
       target_capacity        = 100
     }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "default" {
+  count              = var.capacity_provider_asg_arn != null ? 1 : 0
+  capacity_providers = [aws_ecs_capacity_provider.default[*].name]
+  cluster_name       = aws_ecs_cluster.default.name
+
+  default_capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = aws_ecs_capacity_provider.default[*].name
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "ecs" {
     protocol    = "-1"
     from_port   = 0
     to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS009
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sgr
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "image" {
   description = "Docker image to run in the ECS cluster"
 }
 
+variable "kms_key_id" {
+  type        = string
+  default     = null
+  description = "The custom KMS key ID used encryption of the Cloudwatch log group"
+}
+
 variable "load_balancer_deregistration_delay" {
   type        = number
   default     = 300

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,9 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    source = "hashicorp/aws"
-    aws    = ">= 4.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.10"
+    source = "hashicorp/aws"
+    aws    = ">= 4.0.0"
   }
 }


### PR DESCRIPTION
This PR updates the module to work with Terraform AWS provider V4:

- Refactored `capacity_providers` of the `aws_ecs_cluster` to the `aws_ecs_cluster_capacity_providers` resource.
- Bumped used module.