### PR TITLE
Fixed local to return null if var.load_balancer_subnet_ids is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 | <a name="input_memory"></a> [memory](#input\_memory) | Fargate instance memory to provision (in MiB) | `number` | `2048` | no |
 | <a name="input_port"></a> [port](#input\_port) | Port exposed by the docker image to redirect traffic to | `number` | `3000` | no |
 | <a name="input_postfix"></a> [postfix](#input\_postfix) | Postfix the role and policy names with Role and Policy | `bool` | `false` | no |
-| <a name="input_protocol"></a> [protocol](#input\_protocol) | The target protocol | `string` | `"HTTP"` | no |
+| <a name="input_protocol"></a> [protocol](#input\_protocol) | The target protocol | `string` | `null` | no |
 | <a name="input_public_ip"></a> [public\_ip](#input\_public\_ip) | Assign a public ip to the service | `bool` | `false` | no |
 | <a name="input_readonly_root_filesystem"></a> [readonly\_root\_filesystem](#input\_readonly\_root\_filesystem) | When this parameter is true, the container is given read-only access to its root file system | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region this fargate cluster should reside in, defaults to the region used by the callee | `string` | `null` | no |

--- a/dns.tf
+++ b/dns.tf
@@ -3,8 +3,8 @@ locals {
     "${var.subdomain.name}.${data.aws_route53_zone.current[0].name}", "/[.]$/", "",
   ) : null
 
-  certificate_arn   = var.certificate_arn != null ? var.certificate_arn : var.protocol != "TCP" ? aws_acm_certificate.default[0].arn : null
-  certificate_count = var.certificate_arn == null && var.subdomain != null && var.protocol != "TCP" ? local.load_balancer_count : 0
+  certificate_arn   = var.certificate_arn != null ? var.certificate_arn : var.protocol == "HTTPS" ? aws_acm_certificate.default[0].arn : null
+  certificate_count = var.certificate_arn == null && var.subdomain != null && var.protocol == "HTTPS" ? local.load_balancer_count : 0
 }
 
 data "aws_route53_zone" "current" {

--- a/dns.tf
+++ b/dns.tf
@@ -3,8 +3,8 @@ locals {
     "${var.subdomain.name}.${data.aws_route53_zone.current[0].name}", "/[.]$/", "",
   ) : null
 
-  certificate_arn   = var.certificate_arn != null ? var.certificate_arn : var.protocol == "HTTPS" ? aws_acm_certificate.default[0].arn : null
-  certificate_count = var.certificate_arn == null && var.subdomain != null && var.protocol == "HTTPS" ? local.load_balancer_count : 0
+  certificate_arn   = var.certificate_arn != null ? var.certificate_arn : var.protocol == "HTTP" ? aws_acm_certificate.default[0].arn : null
+  certificate_count = var.certificate_arn == null && var.subdomain != null && var.protocol == "HTTP" ? local.load_balancer_count : 0
 }
 
 data "aws_route53_zone" "current" {

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_security_group" "ecs" {
   tags        = var.tags
 
   dynamic "ingress" {
-    for_each = local.load_balancer
+    for_each = local.load_balancer_count
 
     content {
       description     = "Allow access from the ECS cluster"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  load_balancer = var.load_balancer_subnet_ids != null ? { create : true } : {}
+  load_balancer = var.load_balancer_subnet_ids != null ? { create : true } : null
   region        = var.region != null ? var.region : data.aws_region.current.name
 
   environment = [

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_security_group" "ecs" {
   tags        = var.tags
 
   dynamic "ingress" {
-    for_each = local.load_balancer_count
+    for_each = aws_lb.default
 
     content {
       description     = "Allow access from the ECS cluster"
@@ -154,7 +154,7 @@ resource "aws_ecs_service" "default" {
   }
 
   dynamic "load_balancer" {
-    for_each = local.load_balancer
+    for_each = aws_lb.default
 
     content {
       target_group_arn = aws_lb_target_group.default.0.id

--- a/variables.tf
+++ b/variables.tf
@@ -127,13 +127,13 @@ variable "postfix" {
 
 variable "protocol" {
   type        = string
-  default     = "HTTP"
+  default     = null
   description = "The target protocol"
 
-  validation {
-    condition     = (var.protocol == null || contains(["HTTP", "TCP"], var.protocol))
-    error_message = "Allowed values for protocol are null, \"HTTP\" or \"TCP\"."
-  }
+  # validation {
+  #   condition     = (var.protocol == null || (coalesce(var.protocol, null)))
+  #   error_message = "Allowed values for protocol are null, \"HTTP\" or \"TCP\"."
+  # }
 }
 
 variable "public_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,8 +131,8 @@ variable "protocol" {
   description = "The target protocol"
 
   validation {
-    condition     = contains(["HTTP", "TCP"], var.protocol)
-    error_message = "Allowed values for protocol are \"HTTP\" or \"TCP\"."
+    condition     = (var.protocol == null || contains(["HTTP", "TCP"], var.protocol))
+    error_message = "Allowed values for protocol are null, \"HTTP\" or \"TCP\"."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -130,10 +130,10 @@ variable "protocol" {
   default     = null
   description = "The target protocol"
 
-  # validation {
-  #   condition     = (var.protocol == null || (coalesce(var.protocol, null)))
-  #   error_message = "Allowed values for protocol are null, \"HTTP\" or \"TCP\"."
-  # }
+  validation {
+    condition     = (var.protocol == null ? true : contains(["HTTP", "TCP"], var.protocol))
+    error_message = "Allowed values for protocol are null, \"HTTP\" or \"TCP\"."
+  }
 }
 
 variable "public_ip" {


### PR DESCRIPTION
The local now returns ‘{}’ instead of ‘null’ resulting in a count-error in lb.tf (in load_balancer_count count)