### PR TITLE
Resolve eip deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 
 ## Modules
 

--- a/lb.tf
+++ b/lb.tf
@@ -48,8 +48,8 @@ resource "aws_eip" "lb" {
   #checkov:skip=CKV2_AWS_19:IP's can also be used for non-EC2 resources
   count = length(local.eip_subnets)
 
-  vpc  = true
-  tags = var.tags
+  domain = "vpc"
+  tags   = var.tags
 }
 
 resource "aws_lb" "default" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR resolved the `aws_eip` deprecation warning that's introduced in [provider v5](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#500-may-25-2023)

See also https://github.com/schubergphilis/terraform-aws-mcaf-vpc/pull/54