### PR TITLE
Attaching an EFS file system to an ECS Task

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -4,10 +4,9 @@ resource "aws_efs_file_system" "default" {
 }
 
 resource "aws_efs_mount_target" "mount" {
-  count          = var.enable_efs ? 1 : 0
+  count          = var.enable_efs ? length(var.ecs_subnet_ids) : 0
   file_system_id = aws_efs_file_system.default[0].id
-  subnet_id      = var.ecs_subnet_ids
-  tags           = var.tags
+  subnet_id      = var.ecs_subnet_ids[count.index]
 }
 
 resource "aws_efs_access_point" "default" {

--- a/efs.tf
+++ b/efs.tf
@@ -5,12 +5,12 @@ resource "aws_efs_file_system" "default" {
 
 resource "aws_efs_mount_target" "mount" {
   count          = var.enable_efs ? 1 : 0
-  file_system_id = aws_efs_file_system.default.id
+  file_system_id = aws_efs_file_system.default[0].id
   subnet_id      = var.ecs_subnet_ids
   tags           = var.tags
 }
 
 resource "aws_efs_access_point" "default" {
   count          = var.enable_efs ? 1 : 0
-  file_system_id = aws_efs_file_system.default.id
+  file_system_id = aws_efs_file_system.default[0].id
 }

--- a/efs.tf
+++ b/efs.tf
@@ -1,0 +1,16 @@
+resource "aws_efs_file_system" "default" {
+  count = var.enable_efs ? 1 : 0
+  tags  = var.tags
+}
+
+resource "aws_efs_mount_target" "mount" {
+  count          = var.enable_efs ? 1 : 0
+  file_system_id = aws_efs_file_system.default.id
+  subnet_id      = var.ecs_subnet_ids
+  tags           = var.tags
+}
+
+resource "aws_efs_access_point" "default" {
+  count          = var.enable_efs ? 1 : 0
+  file_system_id = aws_efs_file_system.default.id
+}

--- a/main.tf
+++ b/main.tf
@@ -83,9 +83,14 @@ resource "aws_ecs_task_definition" "default" {
     content {
       name = "${var.name}-efs"
       efs_volume_configuration {
-        file_system_id     = var.efs_file_system_id
-        root_directory     = var.efs_root_directory
-        transit_encryption = "ENABLED"
+        file_system_id          = var.efs_file_system_id
+        root_directory          = var.efs_root_directory
+        transit_encryption      = "ENABLED"
+        transit_encryption_port = 2999
+        authorization_config {
+          access_point_id = var.efs_access_point_id
+          iam             = "ENABLED"
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -61,12 +61,26 @@ resource "aws_ecs_task_definition" "default" {
     port                   = var.port
     cpu                    = var.cpu
     memory                 = var.memory
+    mountPoints            = [for p in var.mount_points : { sourceVolume = "${var.name}-efs" }]
     log_group              = aws_cloudwatch_log_group.default.name
     environment            = jsonencode(local.environment)
     secrets                = jsonencode(local.secrets)
     readonlyRootFilesystem = var.readonly_root_filesystem
     region                 = local.region
   })
+
+  dynamic "volume" {
+    for_each = var.efs_file_system_id == null ? [] : [1]
+
+    content {
+      name = "${var.name}-efs"
+      efs_volume_configuration {
+        file_system_id     = var.efs_file_system_id
+        root_directory     = var.efs_root_directory
+        transit_encryption = "ENABLED"
+      }
+    }
+  }
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
   ]
 
   updated_mount_points = [
-    for mount in var.mount_points :
+    for mount in var.efs_mount_points :
     {
       sourceVolume  = "${var.name}-efs"
       containerPath = mount.containerPath
@@ -78,17 +78,17 @@ resource "aws_ecs_task_definition" "default" {
   })
 
   dynamic "volume" {
-    for_each = var.efs_file_system_id == null ? [] : [1]
+    for_each = var.enable_efs == null ? [1] : []
 
     content {
       name = "${var.name}-efs"
       efs_volume_configuration {
-        file_system_id          = var.efs_file_system_id
-        root_directory          = var.efs_root_directory
+        file_system_id          = aws_efs_file_system.default.id
+        root_directory          = "/opt/data"
         transit_encryption      = "ENABLED"
         transit_encryption_port = 2999
         authorization_config {
-          access_point_id = var.efs_access_point_id
+          access_point_id = aws_efs_access_point.default.id
           iam             = "ENABLED"
         }
       }

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,13 @@ locals {
       valueFrom = v
     }
   ]
+
+  updated_mount_points = [
+    for mount in var.mount_points :
+    {
+      sourceVolume = "${var.name}-efs"
+    }
+  ]
 }
 
 data "aws_region" "current" {}
@@ -61,7 +68,7 @@ resource "aws_ecs_task_definition" "default" {
     port                   = var.port
     cpu                    = var.cpu
     memory                 = var.memory
-    mountPoints            = [for p in var.mount_points : { sourceVolume = "${var.name}-efs" }]
+    mountPoints            = local.updated_mount_points
     log_group              = aws_cloudwatch_log_group.default.name
     environment            = jsonencode(local.environment)
     secrets                = jsonencode(local.secrets)

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "aws_ecs_task_definition" "default" {
   })
 
   dynamic "volume" {
-    for_each = var.enable_efs == null ? [1] : []
+    for_each = var.enable_efs ? [1] : []
 
     content {
       name = "${var.name}-efs"

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,8 @@ locals {
   updated_mount_points = [
     for mount in var.mount_points :
     {
-      sourceVolume = "${var.name}-efs"
+      sourceVolume  = "${var.name}-efs"
+      containerPath = mount.containerPath
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -83,12 +83,12 @@ resource "aws_ecs_task_definition" "default" {
     content {
       name = "${var.name}-efs"
       efs_volume_configuration {
-        file_system_id          = aws_efs_file_system.default.id
+        file_system_id          = aws_efs_file_system.default[0].id
         root_directory          = "/opt/data"
         transit_encryption      = "ENABLED"
         transit_encryption_port = 2999
         authorization_config {
-          access_point_id = aws_efs_access_point.default.id
+          access_point_id = aws_efs_access_point.default[0].id
           iam             = "ENABLED"
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,12 @@ variable "efs_file_system_id" {
 variable "efs_root_directory" {
   type        = string
   default     = "/opt/data"
-  description = "Root directory of EFS if attached"
+  description = "Optional. Root directory of EFS if attached"
+}
+
+variable "efs_access_point_id" {
+  type        = string
+  description = "EFS access point ID to use in authorizationConfig"
 }
 
 variable "enable_container_insights" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "ecs_subnet_ids" {
 
 variable "enable_efs" {
   type        = bool
-  default     = true
+  default     = false
   description = "Enable EFS volume creation and attachment to the container"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -141,7 +141,9 @@ variable "memory" {
 }
 
 variable "mount_points" {
-  type        = list(map(string))
+  type = list(object({
+    containerPath = string
+  }))
   default     = []
   description = "The mount points for data volumes in your container. This parameter maps to Volumes in the --volume option to docker run"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,18 @@ variable "ecs_subnet_ids" {
   description = "List of subnet IDs assigned to ECS cluster"
 }
 
+variable "efs_file_system_id" {
+  type        = string
+  default     = null
+  description = "Attach an EFS file system to the ECS Task by this EFS id"
+}
+
+variable "efs_root_directory" {
+  type        = string
+  default     = "/opt/data"
+  description = "Root directory of EFS if attached"
+}
+
 variable "enable_container_insights" {
   type        = bool
   default     = true
@@ -126,6 +138,12 @@ variable "memory" {
   type        = number
   default     = 2048
   description = "Fargate instance memory to provision (in MiB)"
+}
+
+variable "mount_points" {
+  type        = list(map(string))
+  default     = []
+  description = "The mount points for data volumes in your container. This parameter maps to Volumes in the --volume option to docker run"
 }
 
 variable "name" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,21 +33,10 @@ variable "ecs_subnet_ids" {
   description = "List of subnet IDs assigned to ECS cluster"
 }
 
-variable "efs_file_system_id" {
-  type        = string
-  default     = null
-  description = "Attach an EFS file system to the ECS Task by this EFS id"
-}
-
-variable "efs_root_directory" {
-  type        = string
-  default     = "/opt/data"
-  description = "Optional. Root directory of EFS if attached"
-}
-
-variable "efs_access_point_id" {
-  type        = string
-  description = "EFS access point ID to use in authorizationConfig"
+variable "enable_efs" {
+  type        = bool
+  default     = true
+  description = "Enable EFS volume creation and attachment to the container"
 }
 
 variable "enable_container_insights" {
@@ -145,7 +134,7 @@ variable "memory" {
   description = "Fargate instance memory to provision (in MiB)"
 }
 
-variable "mount_points" {
+variable "efs_mount_points" {
   type = list(object({
     containerPath = string
   }))


### PR DESCRIPTION
**Attaching an EFS file system to an ECS Task**

When enable_efs variable set to true, and EFS volume is created and attached to the container.

EFS configuration uses transit_encryption enabled to comply with tfsec: https://aquasecurity.github.io/tfsec/v1.8.0/checks/aws/ecs/enable-in-transit-encryption/

optional mount_points variable can be used to indicate container paths:
"mountPoints": [
          {
              "containerPath": "/usr/share/nginx/html"
          }
      ]