### PR TITLE
remove root directory

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,6 @@ resource "aws_ecs_task_definition" "default" {
       name = "${var.name}-efs"
       efs_volume_configuration {
         file_system_id          = aws_efs_file_system.default[0].id
-        root_directory          = "/opt/data"
         transit_encryption      = "ENABLED"
         transit_encryption_port = 2999
         authorization_config {


### PR DESCRIPTION
The error occured depending on last PR
ClientException: When using an EFS access point, the root directory must either be set to "/" or be omitted.
I removed root directory.