### PR TITLE
add aws_security_group and enable data encryption in rest

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -24,18 +24,18 @@ resource "aws_security_group" "allow_efs_mount" {
   vpc_id      = var.vpc_id
 
   ingress {
-    description = "EFS transit encryption port"
-    protocol    = "tcp"
-    from_port   = 2999
-    to_port     = 2999
+    description     = "EFS transit encryption port"
+    protocol        = "tcp"
+    from_port       = 2999
+    to_port         = 2999
     security_groups = [aws_security_group.ecs.id]
   }
 
   ingress { # fails to mount if not added
-    description = "Standard EFS port"
-    protocol    = "tcp"
-    from_port   = 2049
-    to_port     = 2049
+    description     = "Standard EFS port"
+    protocol        = "tcp"
+    from_port       = 2049
+    to_port         = 2049
     security_groups = [aws_security_group.ecs.id]
   }
 }

--- a/efs.tf
+++ b/efs.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "allow_efs_mount" {
     protocol    = "tcp"
     from_port   = 2999
     to_port     = 2999
-    cidr_blocks = var.cidr_blocks #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+    security_groups = [aws_security_group.ecs.id]
   }
 
   ingress { # fails to mount if not added
@@ -36,6 +36,6 @@ resource "aws_security_group" "allow_efs_mount" {
     protocol    = "tcp"
     from_port   = 2049
     to_port     = 2049
-    cidr_blocks = var.cidr_blocks #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+    security_groups = [aws_security_group.ecs.id]
   }
 }

--- a/efs.tf
+++ b/efs.tf
@@ -1,15 +1,41 @@
 resource "aws_efs_file_system" "default" {
-  count = var.enable_efs ? 1 : 0
-  tags  = var.tags
+  count      = var.enable_efs ? 1 : 0
+  encrypted  = true
+  kms_key_id = var.kms_key_id
+  tags       = var.tags
 }
 
 resource "aws_efs_mount_target" "mount" {
-  count          = var.enable_efs ? length(var.ecs_subnet_ids) : 0
-  file_system_id = aws_efs_file_system.default[0].id
-  subnet_id      = var.ecs_subnet_ids[count.index]
+  count           = var.enable_efs ? length(var.ecs_subnet_ids) : 0
+  file_system_id  = aws_efs_file_system.default[0].id
+  subnet_id       = var.ecs_subnet_ids[count.index]
+  security_groups = [aws_security_group.allow_efs_mount[0].id]
 }
 
 resource "aws_efs_access_point" "default" {
   count          = var.enable_efs ? 1 : 0
   file_system_id = aws_efs_file_system.default[0].id
+}
+
+resource "aws_security_group" "allow_efs_mount" {
+  count       = var.enable_efs ? 1 : 0
+  name        = "${var.name}-efs-transit-encryption"
+  description = "Allow mounting for EFS volume"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "EFS transit encryption port"
+    protocol    = "tcp"
+    from_port   = 2999
+    to_port     = 2999
+    cidr_blocks = var.cidr_blocks #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  }
+
+  ingress { # fails to mount if not added
+    description = "Standard EFS port"
+    protocol    = "tcp"
+    from_port   = 2049
+    to_port     = 2049
+    cidr_blocks = var.cidr_blocks #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  }
 }


### PR DESCRIPTION
Problem: 
When enable_efs feature flag is enabled, the resources created but the volume is not attached at runtime.

Story:
While the previous development creates resources properly, the EFS volume was not being mounted when the container is being commissioned. Note that this is not about TF but a runtime issue. I thought container is in a subnet but there is no way to communicate to EFS service. This PR adds aws_security_group meanwhile adds data encryption at rest.

Testing: 
Terraform validated, applied and seen the resources created. I experimented the volume creation at AWS console manually. I also tried to deploy all workload environment in a sandbox account to see all process end to end, however this has failed for many reasons. I can't be sure 100% but this should work.

Heads Up: 
Because the previous version does not really work, it will be good to keep same version release number as 0.16.0