### PR TITLE
Add EFS name

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -1,8 +1,9 @@
 resource "aws_efs_file_system" "default" {
-  count      = var.enable_efs ? 1 : 0
-  encrypted  = true
-  kms_key_id = var.kms_key_id
-  tags       = var.tags
+  count          = var.enable_efs ? 1 : 0
+  encrypted      = true
+  kms_key_id     = var.kms_key_id
+  creation_token = local.efs_name
+  tags           = local.efs_tags
 }
 
 resource "aws_efs_mount_target" "mount" {

--- a/main.tf
+++ b/main.tf
@@ -18,10 +18,14 @@ locals {
     }
   ]
 
+  efs_name = "${var.name}-efs"
+
+  efs_tags = merge(var.tags, { "Name" = local.efs_name })
+
   updated_mount_points = [
     for mount in var.efs_mount_points :
     {
-      sourceVolume  = "${var.name}-efs"
+      sourceVolume  = local.efs_name
       containerPath = mount.containerPath
     }
   ]
@@ -81,7 +85,7 @@ resource "aws_ecs_task_definition" "default" {
     for_each = var.enable_efs ? [1] : []
 
     content {
-      name = "${var.name}-efs"
+      name = local.efs_name
       efs_volume_configuration {
         file_system_id          = aws_efs_file_system.default[0].id
         transit_encryption      = "ENABLED"


### PR DESCRIPTION
Problem: mountPoints setting in aws_ecs_task_definition is not effective.

Solution: Same efs name must be passed to aws_efs_file_system as a Name variable in tags collection.

References:
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system#tags
- https://docs.aws.amazon.com/efs/latest/ug/API_CreateFileSystem.html

Example sections for expected result:
```
updated_mount_points = [
  {
    "containerPath" = "/data"
    "sourceVolume" = "efs-name" # must be same in aws_efs_file_system.default.tags.Name
  },
]
```

```
resource "aws_efs_file_system" "default" {
  ...
  creation_token = "efs-name"
  tags = {
     Name = "efs-name"
  }
}
```