### PR TITLE
EFS Access point configuration additions and EFS Policy addition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -142,6 +142,12 @@ variable "efs_mount_points" {
   description = "The mount points for data volumes in your container. This parameter maps to Volumes in the --volume option to docker run"
 }
 
+variable "efs_posix_user" {
+  type        = list(number)
+  default     = [1000, 1000]
+  description = "Posix uid and guid needs to be mapped at EFS Access Point"
+}
+
 variable "name" {
   type        = string
   description = "Name of the Fargate cluster"


### PR DESCRIPTION
The problem was EFS can not be written by container users even by root user.

After a week of correspondence with AWS Support and EFS Internal team, the problem is solved and tested. Here the tricky part is configuring Access Point, specifically setting a path. We used a hard coded name "/my-data". It doesn't matter the name, because It will be mounted as the root for that EFS Access Point, so you won't actually see a path name in your ECS app. Why this required is explained here: [stackoverflow](https://stackoverflow.com/questions/72744692/cannot-write-to-efs-mounted-on-container-on-ec2-and-ecs)

I have to add a tf variable for posix uid and guid, which needs to be set same as container user.

I also added a typical access policy for EFS.