### PR TITLE
add mountPoints to the template

### DIFF
--- a/templates/container_definition.tpl
+++ b/templates/container_definition.tpl
@@ -4,6 +4,7 @@
     "image": "${image}",
     "cpu": ${cpu},
     "memory": ${memory},
+    "mountPoints": ${jsonencode(mountPoints)},
     "networkMode": "awsvpc",
     "environment": ${environment},
     "readonlyRootFilesystem": ${readonlyRootFilesystem},


### PR DESCRIPTION
Add a missing entry to the template file which defines ecs_task_definition.

mountPoints comes from variables, processed in locals and given as parameter to ecs task definition template.

For testing, I tried to see the result in tf plan, it doesn't give an error but it doesn't show that detail either. 