### PR TITLE
Add support for Graviton

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ resource "aws_ecs_task_definition" "default" {
   memory                   = var.memory
 
   container_definitions = templatefile("${path.module}/templates/container_definition.tpl", {
+    architecture           = upper(var.architecture)
     name                   = var.name
     image                  = var.image
     port                   = var.port

--- a/templates/container_definition.tpl
+++ b/templates/container_definition.tpl
@@ -8,6 +8,7 @@
     "networkMode": "awsvpc",
     "environment": ${environment},
     "readonlyRootFilesystem": ${readonlyRootFilesystem},
+    "runtimePlatform": { "cpuArchitecture": "${architecture}" },
     "secrets": ${secrets},
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "architecture" {
+  type        = string
+  default     = "x86_64"
+  description = "Instruction set architecture of the Fargate instance"
+
+  validation {
+    condition     = contains(["arm64", "x86_64"], var.architecture)
+    error_message = "Allowed values are \"arm64\" or \"x86_64\"."
+  }
+}
 variable "capacity_provider_asg_arn" {
   type        = string
   default     = null


### PR DESCRIPTION
This PR adds support for Graviton by making the Architecture configurable.

Kept the variable name (and values) in line with the [Lambda configuration](https://github.com/schubergphilis/terraform-aws-mcaf-lambda/blob/master/variables.tf#L1) so it's sort of consistent.