### PR TITLE
Add health check grace period to ECS service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,12 +173,13 @@ resource "aws_ecs_cluster_capacity_providers" "default" {
 }
 
 resource "aws_ecs_service" "default" {
-  name            = var.name
-  cluster         = aws_ecs_cluster.default.id
-  task_definition = aws_ecs_task_definition.default.arn
-  desired_count   = var.desired_count
-  launch_type     = var.service_launch_type
-  propagate_tags  = "TASK_DEFINITION"
+  name                              = var.name
+  cluster                           = aws_ecs_cluster.default.id
+  task_definition                   = aws_ecs_task_definition.default.arn
+  desired_count                     = var.desired_count
+  launch_type                       = var.service_launch_type
+  propagate_tags                    = "TASK_DEFINITION"
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
 
   network_configuration {
     security_groups  = [aws_security_group.ecs.id]

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "health_check" {
 variable "health_check_grace_period_seconds" {
   description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown. Only valid for services configured to use load balancers."
   type        = number
-  default     = 0
+  default     = null
 }
 
 variable "image" {

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,12 @@ variable "health_check" {
   description = "Health check settings for the container"
 }
 
+variable "health_check_grace_period_seconds" {
+  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown. Only valid for services configured to use load balancers."
+  type        = number
+  default     = 0
+}
+
 variable "image" {
   type        = string
   description = "Docker image to run in the ECS cluster"


### PR DESCRIPTION
**Problem:**
Containers with long startup times are failing to commission successfully due to load balancer health checks terminating them before the application has time to start up and become ready.

**Solution:**
Introduce the `health_check_grace_period_seconds` parameter to the ECS service resource. This parameter allows us to specify a grace period during which ECS will ignore failing load balancer health checks on newly instantiated tasks, preventing premature shutdown.

**Details:**
- Added `health_check_grace_period_seconds` parameter to the `aws_ecs_service` resource.
- Created a new variable `health_check_grace_period_seconds` with a default value of null to maintain backwards compatibility.

While the module already has a `[health_check](https://github.com/schubergphilis/terraform-aws-mcaf-fargate/blob/52170c2e0c3b3c2f5eb3f99d5d986291f8ce8256/lb.tf#L123)` block for configuring the Load Balancer's health check parameters, increasing these values would also increase the regular health check window, potentially delaying detection of application failures. The grace period provides a more targeted solution for the container commissioning phase.

This change allows users to set an appropriate grace period for their applications to start up, without affecting the ongoing health check behavior once the application is running.

**Testing:**
- Tested with various grace period values to ensure proper behavior during task startup.
- Verified that setting the value to 0 (default) maintains the current behavior for backwards compatibility.
- Confirmed that the grace period does not affect regular health check behavior after the initial startup phase.

**Related documentation:**
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#health_check_grace_period_seconds
