### PR TITLE
fix: Add moved to prevent recreation

### DIFF
--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = aws_route53_record.validation[0]
+  to   = aws_route53_record.validation["create"]
+}


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Add a moved statement to prevent recreation of the validation records

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
