### PR TITLE
feature: As a best practise, always enable backup for the EFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | [aws_ecs_service.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_efs_access_point.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
+| [aws_efs_backup_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_backup_policy) | resource |
 | [aws_efs_file_system.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_file_system_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system_policy) | resource |
 | [aws_efs_mount_target.mount](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |

--- a/efs.tf
+++ b/efs.tf
@@ -89,3 +89,13 @@ resource "aws_security_group" "allow_efs_mount" {
     security_groups = [aws_security_group.ecs.id]
   }
 }
+
+resource "aws_efs_backup_policy" "default" {
+  count = var.enable_efs ? 1 : 0
+
+  file_system_id = aws_efs_file_system.default[0].id
+
+  backup_policy {
+    status = "ENABLED"
+  }
+}


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Security hub triggers if an EFS volume is not configured to be backed up. This PR configures it to be always part of the backup.

See also [EFS.2](https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-2)

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
