### PR TITLE
fix: Correct SSL Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | <a name="input_region"></a> [region](#input\_region) | The region this fargate cluster should reside in, defaults to the region used by the callee | `string` | `null` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | Map containing secrets to expose to the docker container | `map(string)` | `{}` | no |
 | <a name="input_service_launch_type"></a> [service\_launch\_type](#input\_service\_launch\_type) | The service launch type: either FARGATE or EC2 | `string` | `"FARGATE"` | no |
-| <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL Policy for the LB Listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06"` | no |
+| <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL Policy for the LB Listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | The DNS subdomain and zone ID for the LB | <pre>object({<br/>    name    = string,<br/>    zone_id = string<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | `{}` | no |
 | <a name="input_target_group_stickiness"></a> [target\_group\_stickiness](#input\_target\_group\_stickiness) | Whether to bind a client’s session to a specific instance within the target group | `bool` | `false` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,16 @@ This document captures required refactoring on your part when upgrading to a mod
 
 Initial release of the module. These changes are based on the last tag version (`v0.16.5`)
 
-### Behaviour (v1.0.0)
+operating_system_family
 
-- The `load_balancer_deletion_protection` variable, is now `true` by default.
-- The Cloudwatch `log_retention_days` is now configurable and the default value is updated from 30 to 365 days.
+### Key Changes
+
+Mainly security related changes and some minor refactoring.
+
+#### Variables
+
+The following variables have been modified:
+
+- `load_balancer_deletion_protection` is now `true` by default.
+- `log_retention_days` is now configurable and the default value is updated from 30 to 365 days.
+- `ssl_policy` is now `ELBSecurityPolicy-TLS13-1-2-2021-06` by default.

--- a/variables.tf
+++ b/variables.tf
@@ -252,12 +252,12 @@ variable "service_launch_type" {
 
 variable "ssl_policy" {
   type        = string
-  default     = "ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06"
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   description = "SSL Policy for the LB Listener"
 
   validation {
-    condition     = contains(["LBSecurityPolicy-TLS13-1-2-Ext1-2021-06", "ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06", "ELBSecurityPolicy-TLS13-1-2-Res-2021-06", "ELBSecurityPolicy-TLS13-1-2-2021-06", "ELBSecurityPolicy-TLS13-1-3-2021-06"], var.ssl_policy)
-    error_message = "Allowed values for ssl_policy are \"LBSecurityPolicy-TLS13-1-2-Ext1-2021-06\", \"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06\", \"ELBSecurityPolicy-TLS13-1-2-Res-2021-06\", \"ELBSecurityPolicy-TLS13-1-2-2021-06\" or \"ELBSecurityPolicy-TLS13-1-3-2021-06\"."
+    condition     = contains(["ELBSecurityPolicy-TLS13-1-2-2021-06", "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04", "ELBSecurityPolicy-TLS13-1-3-2021-06", "ELBSecurityPolicy-TLS13-1-3-FIPS-2023-04", "ELBSecurityPolicy-TLS13-1-2-Res-2021-06", "ELBSecurityPolicy-TLS13-1-2-Res-FIPS-2023-04"], var.ssl_policy)
+    error_message = "Allowed values for ssl_policy are \"ELBSecurityPolicy-TLS13-1-2-2021-06\", \"ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04\", \"ELBSecurityPolicy-TLS13-1-3-2021-06\", \"ELBSecurityPolicy-TLS13-1-3-FIPS-2023-04\", \"ELBSecurityPolicy-TLS13-1-2-Res-2021-06\" or \"ELBSecurityPolicy-TLS13-1-2-Res-FIPS-2023-04\"."
   }
 }
 


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Correct the default SSL policy and set validation to match [Security Hub](https://docs.aws.amazon.com/securityhub/latest/userguide/elb-controls.html#elb-17)

**:rocket: Motivation**
Updates the policy but when checking in Security hub, noticed that the default value is still throwing a `MEDIUM` finding. 

Updated the SSL Policy so valid values are the ones specified in [Security Hub](https://docs.aws.amazon.com/securityhub/latest/userguide/elb-controls.html#elb-17).

**:pencil: Additional Information**
Default is changes to a version that still supports TLS 1.2. I want to make it work a bit of backwards compatible (cannot control all the clients).

Also a small documentation tweak to update `UPGRADING.md`
