### PR TITLE
chore: Updating for deprecation in 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   load_balancer = var.load_balancer_subnet_ids != null ? { create : true } : null
-  region        = var.region != null ? var.region : data.aws_region.current.name
+  region        = var.region != null ? var.region : data.aws_region.current.region
 
   environment = [
     for k, v in var.environment :

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

AWS 6.0.0 deprecated `data.aws_region.current.name` for `data.aws_region.current.region`

Making sure we can use 6.0.0 without warnings

## :rocket: Motivation

Making sure we can use 6.0.0 without warnings
