### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -99,7 +99,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | <a name="input_protocol"></a> [protocol](#input\_protocol) | The target protocol | `string` | `null` | no |
 | <a name="input_public_ip"></a> [public\_ip](#input\_public\_ip) | Assign a public ip to the service | `bool` | `false` | no |
 | <a name="input_readonly_root_filesystem"></a> [readonly\_root\_filesystem](#input\_readonly\_root\_filesystem) | When this parameter is true, the container is given read-only access to its root file system | `bool` | `true` | no |
-| <a name="input_region"></a> [region](#input\_region) | The region this fargate cluster should reside in, defaults to the region used by the callee | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | Map containing secrets to expose to the docker container | `map(string)` | `{}` | no |
 | <a name="input_service_launch_type"></a> [service\_launch\_type](#input\_service\_launch\_type) | The service launch type: either FARGATE or EC2 | `string` | `"FARGATE"` | no |
 | <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL Policy for the LB Listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |

--- a/dns.tf
+++ b/dns.tf
@@ -26,7 +26,9 @@ resource "aws_route53_record" "default" {
 }
 
 resource "aws_acm_certificate" "default" {
-  count             = local.certificate_count
+  count = local.certificate_count
+
+  region            = var.region
   domain_name       = local.application_fqdn
   validation_method = "DNS"
   tags              = var.tags
@@ -55,7 +57,9 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  count                   = local.certificate_count
+  count = local.certificate_count
+
+  region                  = var.region
   certificate_arn         = local.certificate_arn
   validation_record_fqdns = [aws_route53_record.validation["create"].fqdn]
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "task_execution_role" {
 
 module "vpc" {
   source  = "schubergphilis/mcaf-vpc/aws"
-  version = "~> 1.22.0"
+  version = "~> 3.0.0"
 
   name                = "redshift-vpc"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]

--- a/lb.tf
+++ b/lb.tf
@@ -14,7 +14,9 @@ locals {
 
 resource "aws_security_group" "lb" {
   #checkov:skip=CKV2_AWS_5: False positive finding, the security group is attached.
-  count       = var.protocol != "TCP" ? local.load_balancer_count : 0
+  count = var.protocol != "TCP" ? local.load_balancer_count : 0
+
+  region      = var.region
   name        = "${var.name}-lb"
   description = "Controls access to the LB"
   vpc_id      = var.vpc_id
@@ -51,13 +53,16 @@ resource "aws_eip" "lb" {
   #checkov:skip=CKV2_AWS_19:IP's can also be used for non-EC2 resources
   count = length(local.eip_subnets)
 
+  region = var.region
   domain = "vpc"
   tags   = var.tags
 }
 
 resource "aws_lb" "default" {
   #checkov:skip=CKV2_AWS_28:WAF not implemnted (yet)
-  count                            = local.load_balancer_count
+  count = local.load_balancer_count
+
+  region                           = var.region
   name                             = var.name
   drop_invalid_header_fields       = var.protocol != "TCP" ? true : null
   internal                         = var.load_balancer_internal #tfsec:ignore:AWS005
@@ -96,7 +101,9 @@ resource "aws_lb" "default" {
 }
 
 resource "aws_lb_listener" "http" {
-  count             = var.protocol == "TCP" ? 0 : local.load_balancer_count
+  count = var.protocol == "TCP" ? 0 : local.load_balancer_count
+
+  region            = var.region
   load_balancer_arn = aws_lb.default[0].id
   port              = 80
   protocol          = "HTTP"
@@ -115,7 +122,9 @@ resource "aws_lb_listener" "http" {
 }
 
 resource "aws_lb_target_group" "default" {
-  count                = local.load_balancer_count
+  count = local.load_balancer_count
+
+  region               = var.region
   name                 = var.name
   deregistration_delay = var.load_balancer_deregistration_delay
   port                 = var.port
@@ -141,7 +150,9 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener" "https" {
-  count             = var.protocol == "TCP" ? 0 : local.load_balancer_count
+  count = var.protocol == "TCP" ? 0 : local.load_balancer_count
+
+  region            = var.region
   load_balancer_arn = aws_lb.default[0].id
   port              = 443
   protocol          = "HTTPS"
@@ -156,7 +167,9 @@ resource "aws_lb_listener" "https" {
 }
 
 resource "aws_lb_listener" "tcp" {
-  count             = var.protocol == "TCP" ? 1 : 0
+  count = var.protocol == "TCP" ? 1 : 0
+
+  region            = var.region
   load_balancer_arn = aws_lb.default[0].id
   port              = var.port
   protocol          = "TCP"

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -248,7 +248,7 @@ variable "readonly_root_filesystem" {
 variable "region" {
   type        = string
   default     = null
-  description = "The region this fargate cluster should reside in, defaults to the region used by the callee"
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
 }
 
 variable "role_policy" {


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the MCAF Fargate Terraform module to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for all related resources, which improves multi-region compatibility and control. Additionally, the AWS provider version is updated to the latest major version.

**Region configuration improvements:** 

* Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the vpc and related resources. If omitted, the default provider region is used.
* Updated all resources to accept and use the `region` variable. This ensures consistent resource creation in the specified region.


## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.
