### PR TITLE
feature: add optional user for task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | Certificate ARN for the LB Listener | `string` | `null` | no |
 | <a name="input_cidr_blocks"></a> [cidr\_blocks](#input\_cidr\_blocks) | CIDR block to allow access to the LB | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_command"></a> [command](#input\_command) | The command to execute inside the container | `list(string)` | `[]` | no |
+| <a name="input_container_user"></a> [container\_user](#input\_container\_user) | Optional user name (or UID) to run the container as | `string` | `null` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | Fargate instance CPU units to provision (1 vCPU = 1024 CPU units) | `number` | `1024` | no |
 | <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | Desired number of docker containers to run | `number` | `null` | no |
 | <a name="input_ecs_scaling_actions_timezone"></a> [ecs\_scaling\_actions\_timezone](#input\_ecs\_scaling\_actions\_timezone) | ECS scaling actions timezone | `string` | `"Europe/Amsterdam"` | no |
@@ -98,7 +99,6 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | <a name="input_load_balancer_subnet_ids"></a> [load\_balancer\_subnet\_ids](#input\_load\_balancer\_subnet\_ids) | List of subnet IDs assigned to the LB | `list(string)` | `null` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | The cloudwatch log group retention in days | `number` | `365` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Fargate instance memory to provision (in MiB) | `number` | `2048` | no |
-| <a name="input_container_user"></a> [container\_user](#input\_container\_user) | Optional user name (or UID) to run the container as | `string` | `null` | no |
 | <a name="input_operating_system_family"></a> [operating\_system\_family](#input\_operating\_system\_family) | The operating system family of the Fargate instance | `string` | `"LINUX"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The permissions boundary to set to TaskExecutionRole | `string` | `null` | no |
 | <a name="input_port"></a> [port](#input\_port) | Port exposed by the docker image to redirect traffic to | `number` | `3000` | no |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | <a name="input_load_balancer_subnet_ids"></a> [load\_balancer\_subnet\_ids](#input\_load\_balancer\_subnet\_ids) | List of subnet IDs assigned to the LB | `list(string)` | `null` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | The cloudwatch log group retention in days | `number` | `365` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Fargate instance memory to provision (in MiB) | `number` | `2048` | no |
+| <a name="input_container_user"></a> [container\_user](#input\_container\_user) | Optional user name (or UID) to run the container as | `string` | `null` | no |
 | <a name="input_operating_system_family"></a> [operating\_system\_family](#input\_operating\_system\_family) | The operating system family of the Fargate instance | `string` | `"LINUX"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The permissions boundary to set to TaskExecutionRole | `string` | `null` | no |
 | <a name="input_port"></a> [port](#input\_port) | Port exposed by the docker image to redirect traffic to | `number` | `3000` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -28,9 +28,10 @@ module "vpc" {
 }
 
 module "pets" {
-  source                   = "../.."
-  name                     = "fargate"
-  image                    = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/pets:latest"
+  source = "../.."
+  name   = "fargate"
+  image  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/pets:latest"
+
   ecs_subnet_ids           = module.vpc.private_subnet_ids
   load_balancer_subnet_ids = module.vpc.public_subnet_ids
   protocol                 = "HTTP"

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,7 @@ locals {
     cpu                    = var.cpu
     memory                 = var.memory
     environment            = local.environment
+    user                   = var.container_user
     entryPoint             = length(var.entrypoint) > 0 ? var.entrypoint : null
     secrets                = local.secrets
     readonlyRootFilesystem = var.readonly_root_filesystem

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "command" {
   description = "The command to execute inside the container"
 }
 
+variable "container_user" {
+  type        = string
+  default     = null
+  description = "Optional user name (or UID) to run the container as"
+}
+
 variable "cpu" {
   type        = number
   default     = 1024


### PR DESCRIPTION
To be able to fix findings for Security Hub control ECS.20

## :hammer_and_wrench: Summary
Feature to be able to add an optional username for the task definition.

## :rocket: Motivation
To comply to Security Hub control ECS.20