### PR TITLE
fix: revert validation record to count-based approach

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -39,20 +39,12 @@ resource "aws_acm_certificate" "default" {
 }
 
 resource "aws_route53_record" "validation" {
-  for_each = {
-    for dvo in flatten([
-      for c in aws_acm_certificate.default : c.domain_validation_options
-      ]) : "create" => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
+  count = local.certificate_count
 
-  name    = each.value.name
-  records = [each.value.record]
+  name    = tolist(aws_acm_certificate.default[0].domain_validation_options)[0].resource_record_name
+  records = [tolist(aws_acm_certificate.default[0].domain_validation_options)[0].resource_record_value]
   ttl     = 60
-  type    = each.value.type
+  type    = tolist(aws_acm_certificate.default[0].domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.current[0].zone_id
 }
 
@@ -61,5 +53,5 @@ resource "aws_acm_certificate_validation" "default" {
 
   region                  = var.region
   certificate_arn         = local.certificate_arn
-  validation_record_fqdns = [aws_route53_record.validation["create"].fqdn]
+  validation_record_fqdns = [for r in aws_route53_record.validation : r.fqdn]
 }

--- a/moved.tf
+++ b/moved.tf
@@ -1,4 +1,4 @@
 moved {
-  from = aws_route53_record.validation[0]
-  to   = aws_route53_record.validation["create"]
+  from = aws_route53_record.validation["create"]
+  to   = aws_route53_record.validation[0]
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->
<!-- You can include the GitHub generated Summary, be sure to review and clean up appropriately. -->

The `for_each` approach introduced in #73 causes a plan-time error because Terraform requires `for_each` keys to be statically known, but ACM `domain_validation_options` are only available after apply.

Since this certificate only has a single domain (no SANs), count is simpler and sidesteps the limitation entirely. Replaces the legacy splat syntax with `tolist()` to satisfy the linter. Includes a moved block to migrate existing state from `validation["create"]` to `validation[0]` without manual state surgery.

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

<img width="1408" height="402" alt="Screenshot 2026-04-30 at 1 45 12 PM" src="https://github.com/user-attachments/assets/9800397a-c322-42b4-883a-9bf9cae05464" />


## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
