### PR TITLE
feature: add an optional working_directory for the task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | The DNS subdomain and zone ID for the LB | <pre>object({<br/>    name    = string,<br/>    zone_id = string<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | `{}` | no |
 | <a name="input_target_group_stickiness"></a> [target\_group\_stickiness](#input\_target\_group\_stickiness) | Whether to bind a client’s session to a specific instance within the target group | `bool` | `false` | no |
+| <a name="input_working_directory"></a> [working\_directory](#input\_working\_directory) | The working directory to run commands inside the container in | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ locals {
     secrets                = local.secrets
     readonlyRootFilesystem = var.readonly_root_filesystem
     mountPoints            = local.updated_mount_points
+    workingDirectory       = var.working_directory
     logConfiguration = {
       logDriver = "awslogs"
       options = {

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ locals {
     readonlyRootFilesystem = var.readonly_root_filesystem
     mountPoints            = local.updated_mount_points
     workingDirectory       = var.working_directory
-    
+
     logConfiguration = {
       logDriver = "awslogs"
       options = {

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ locals {
     readonlyRootFilesystem = var.readonly_root_filesystem
     mountPoints            = local.updated_mount_points
     workingDirectory       = var.working_directory
+    
     logConfiguration = {
       logDriver = "awslogs"
       options = {

--- a/variables.tf
+++ b/variables.tf
@@ -368,3 +368,9 @@ variable "vpc_id" {
   type        = string
   description = "AWS vpc id"
 }
+
+variable "working_directory" {
+  type        = string
+  default     = null
+  description = "The working directory to run commands inside the container in"
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary
Feature: to be able to add an optional working_directory for the task definition.

<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->
<!-- You can include the GitHub generated Summary, be sure to review and clean up appropriately. -->

## :rocket: Motivation
It lets you avoid repeatedly using cd and absolute paths, makes the Dockerfile cleaner, and ensures commands like RUN, CMD, COPY, and ENTRYPOINT execute in a predictable location.

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
